### PR TITLE
fix: allow for of loops

### DIFF
--- a/rules/joinbox-custom.js
+++ b/rules/joinbox-custom.js
@@ -19,5 +19,7 @@ module.exports = {
         'class-methods-use-this': 'off',
         // don't require an extensions for imports from packages
         'import/extensions': 'ignorePackages',
+        // allow for of loops
+        'no-restricted-syntax': ['ForInStatement']
     },
 };

--- a/rules/joinbox-custom.js
+++ b/rules/joinbox-custom.js
@@ -20,6 +20,8 @@ module.exports = {
         // don't require an extensions for imports from packages
         'import/extensions': 'ignorePackages',
         // allow for of loops
-        'no-restricted-syntax': ['error', 'ForInStatement']
+        'no-restricted-syntax': ['error', 'ForInStatement'],
+        // allow async operations in loops
+        'no-await-in-loop': 'off',
     },
 };

--- a/rules/joinbox-custom.js
+++ b/rules/joinbox-custom.js
@@ -20,6 +20,6 @@ module.exports = {
         // don't require an extensions for imports from packages
         'import/extensions': 'ignorePackages',
         // allow for of loops
-        'no-restricted-syntax': ['ForInStatement']
+        'no-restricted-syntax': ['error', 'ForInStatement']
     },
 };


### PR DESCRIPTION
I can't figure what's not OK with them in some cases (like when working on async code). Airbnbs argumentation is about immutability. Mine is about readability and ease of use. I like iterators, they are great! See https://github.com/airbnb/javascript#iterators-and-generators and https://github.com/airbnb/javascript/issues/1122#issuecomment-259876436