### PR TITLE
fix: allow the use of unary operators

### DIFF
--- a/rules/joinbox-custom.js
+++ b/rules/joinbox-custom.js
@@ -36,5 +36,7 @@ module.exports = {
         }],
         // allow the else statement after an eraly return
         'no-else-return': 'off',
+        // allow ++ / --
+        'no-plusplus': 'off'
     },
 };

--- a/rules/joinbox-custom.js
+++ b/rules/joinbox-custom.js
@@ -34,7 +34,7 @@ module.exports = {
         'indent': ['error', 4, {
             SwitchCase: 1
         }],
-        // allow the else statement after an eraly return
+        // allow the else statement after an early return
         'no-else-return': 'off',
         // allow ++ / --
         'no-plusplus': 'off'


### PR DESCRIPTION
since joinbox uses semicolons everywhere there should be no problem when turning off this rule. https://eslint.org/docs/rules/no-plusplus